### PR TITLE
Breakpoints issues, depends on 'vite-plugin-vue-setup-extend-plus' instead of 'vite-plugin-vue-setup-extend'

### DIFF
--- a/build/plugin/index.js
+++ b/build/plugin/index.js
@@ -4,7 +4,7 @@ import vue from '@vitejs/plugin-vue'
  * * 扩展setup插件，支持在script标签中使用name属性
  * usage: <script setup name="MyComp"></script>
  */
-import VueSetupExtend from 'vite-plugin-vue-setup-extend'
+import vueSetupExtend from 'vite-plugin-vue-setup-extend-plus'
 
 /**
  * * unocss插件，原子css
@@ -20,7 +20,7 @@ import { configMockPlugin } from './mock'
 import unplugin from './unplugin'
 
 export function createVitePlugins(viteEnv, isBuild) {
-  const plugins = [vue(), VueSetupExtend(), ...unplugin, configHtmlPlugin(viteEnv, isBuild), Unocss()]
+  const plugins = [vue(), vueSetupExtend(), ...unplugin, configHtmlPlugin(viteEnv, isBuild), Unocss()]
 
   if (viteEnv?.VITE_APP_USE_MOCK) {
     plugins.push(configMockPlugin(isBuild))

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "vite": "^2.9.9",
     "vite-plugin-html": "^3.2.0",
     "vite-plugin-mock": "^2.9.6",
-    "vite-plugin-vue-setup-extend": "^0.3.0"
+    "vite-plugin-vue-setup-extend-plus": "^0.1.0"
   }
 }


### PR DESCRIPTION
Solved the problem that the breakpoint is not in the source code location when debugging.