### PR TITLE
fix: 修复权限树只选择一项权限时会清空所有权限的问题

### DIFF
--- a/src/views/pms/role/components/CascadeTree.vue
+++ b/src/views/pms/role/components/CascadeTree.vue
@@ -46,7 +46,7 @@ const emit = defineEmits(['update:value'])
 const halfCheckedKeys = ref([])
 const checkedKeys = ref([])
 watch([halfCheckedKeys, checkedKeys], ([v1, v2]) => {
-  emit('update:value', new Array(...new Set([...v1, ...v2])))
+  emit('update:value', Array.from(new Set([...v1, ...v2])))
 })
 onMounted(() => {
   halfCheckedKeys.value = getHalfCheckedValues(props.value, props.treeData)


### PR DESCRIPTION
当 `[...v1, ...v2]` 只有一个元素时，例如：`new Array(...new Set([3]))`，得到的结果是：`[undefined, undefined, undefined]`，元素的个数取决于这个单一的元素是什么