### PR TITLE
fix:修复菜单 collapse 状态图标指示错误

### DIFF
--- a/src/layouts/components/MenuCollapse.vue
+++ b/src/layouts/components/MenuCollapse.vue
@@ -11,7 +11,7 @@
     class="f-c-c cursor-pointer rounded-4 p-6 text-22 transition-all-300 auto-bg-hover"
     @click="appStore.switchCollapsed"
   >
-    <i :class="appStore.collapsed ? 'i-line-md-menu-unfold-left' : 'i-line-md-menu-fold-left'" />
+    <i :class="appStore.collapsed ? 'i-line-md-menu-unfold-right' : 'i-line-md-menu-fold-left'" />
   </div>
 </template>
 


### PR DESCRIPTION
修复了菜单缩进时状态图标的错误，修改后如下图所示：

![image](https://github.com/zclzone/vue-naive-admin/assets/8016493/ccc46a15-ab9f-4fec-9be9-426eeab884f0)
