### PR TITLE
fix: 修复naive-ui预览图片时toolbar样式问题

### DIFF
--- a/src/components/me/modal/utils.js
+++ b/src/components/me/modal/utils.js
@@ -63,7 +63,6 @@ export function initDrag(bar, box) {
     }
   }
   document.onmousemove = function (e) {
-    e.preventDefault() // 阻止默认事件
     // 如果拖拽标志为true
     if (params.flag) {
       const nowX = e.clientX // 鼠标当前位置的X坐标

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -72,3 +72,10 @@ body {
     }
   }
 }
+
+/**
+  * naive-ui样式覆盖
+  */
+body .n-image-preview-toolbar .n-base-icon {
+  box-sizing: content-box;
+}


### PR DESCRIPTION
因为给所有的元素添加了box-sizing: border-box;
导致naive-ui预览图片的toolbar样式不符合预期；
![2e551f9973a7dc04e27f5883cf98e7b](https://github.com/zclzone/vue-naive-admin/assets/34200319/8b4c0ee1-df3c-4b14-9ab8-dbfcd8e16c5c)

![7473c27b40ef1b955f795d27a39aff1](https://github.com/zclzone/vue-naive-admin/assets/34200319/4a958de4-adf6-4cee-92a5-51bb6a9deea0)
