### PR TITLE
🐞 fix(ResError): 退出登录接口401登陆界面关闭确认弹窗

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -14,7 +14,7 @@ export default {
   // 刷新token
   refreshToken: () => request.get('/auth/refresh/token'),
   // 登出
-  logout: () => request.post('/auth/logout'),
+  logout: () => request.post('/auth/logout', null, { noNeedTip401: true }),
   // 切换当前角色
   switchCurrentRole: role => request.post(`/auth/current-role/switch/${role}`),
   // 获取角色权限

--- a/src/utils/http/helpers.js
+++ b/src/utils/http/helpers.js
@@ -8,11 +8,15 @@
  **********************************/
 
 import { useAuthStore } from '@/store'
+import { isNullOrUndef } from '../is'
 
 let isConfirming = false
-export function resolveResError(code, message) {
+export function resolveResError(code, message, config = {}) {
   switch (code) {
     case 401:
+      const { noNeedTip401 } = config
+      if (!isNullOrUndef(noNeedTip401) && noNeedTip401)
+         return 
       if (isConfirming)
         return
       isConfirming = true

--- a/src/utils/http/interceptors.js
+++ b/src/utils/http/interceptors.js
@@ -40,7 +40,7 @@ export function setupInterceptors(axiosInstance) {
       const code = data?.code ?? status
 
       // 根据code处理对应的操作，并返回处理后的message
-      const message = resolveResError(code, data?.message ?? statusText)
+      const message = resolveResError(code, data?.message ?? statusText, config)
 
       // 需要错误提醒
       !config?.noNeedTip && message && window.$message?.error(message)
@@ -61,7 +61,7 @@ export function setupInterceptors(axiosInstance) {
     const { data, status, config } = error.response
     const code = data?.code ?? status
 
-    const message = resolveResError(code, data?.message ?? error.message)
+    const message = resolveResError(code, data?.message ?? error.message, config)
     /** 需要错误提醒 */
     !config?.noNeedTip && message && window.$message?.error(message)
     return Promise.reject({ code, message, error: error.response?.data || error.response })


### PR DESCRIPTION
页面长期挂着，token过期后点击退出登录时接口401，但是已经在登录界面会出现确认弹窗。如果是这种场景感觉不出现二次确认弹窗会体验好一点.